### PR TITLE
Better options setting for session

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -63,10 +63,10 @@ function JanusSession(output, options) {
   this.id = undefined;
   this.nextTxId = 0;
   this.txns = {};
-  this.options = options || {
+  this.options = Object.assign({
     timeoutMs: 10000,
     keepaliveMs: 30000
-  };
+  }, options);
 }
 
 /** Creates this session on the Janus server and sets its ID. **/

--- a/minijanus.js
+++ b/minijanus.js
@@ -62,10 +62,10 @@ function JanusSession(output, options) {
   this.id = undefined;
   this.nextTxId = 0;
   this.txns = {};
-  this.options = options || {
+  this.options = Object.assign({
     timeoutMs: 10000,
     keepaliveMs: 30000
-  };
+  }, options);
 }
 
 /** Creates this session on the Janus server and sets its ID. **/

--- a/tests.js
+++ b/tests.js
@@ -2,7 +2,7 @@ var mj = require('./minijanus.js');
 var test = require('tape');
 
 test('transactions are detected and matched up', function(t) {
-  var session = new mj.JanusSession(signal => {}, {});
+  var session = new mj.JanusSession(signal => {}, { keepaliveMs: null });
 
   var aq = session.send({ transaction: "figs" });
   var bq = session.send({ transaction: "wigs" });
@@ -24,7 +24,7 @@ test('transactions are detected and matched up', function(t) {
 });
 
 test('transaction timeouts happen', function(t) {
-  var session = new mj.JanusSession(signal => {}, { timeoutMs: 5 });
+  var session = new mj.JanusSession(signal => {}, { timeoutMs: 5, keepaliveMs: null });
 
   var aq = session.send({ transaction: "lazy" }).then(
     resp => t.error(true, "Request should have failed!"),


### PR DESCRIPTION
Addresses #1.

Now each option gets its default independently, so if you do
```Javascript
new Session(sendFn, { timeoutMs: 15000 })
```
the session will still have the default `keepaliveMs` of 30000.