### PR TITLE
Hint property unnecessary to signal acks

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -106,7 +106,7 @@ JanusSession.prototype.receive = function(signal) {
   }
   if (signal.transaction != null) {
     var handlers = this.txns[signal.transaction];
-    if (signal.janus === "ack" && signal.hint) {
+    if (signal.janus === "ack") {
       // this is an ack of an asynchronously-processed request, we should wait
       // to resolve the promise until the actual response comes in
     } else if (handlers != null) {

--- a/minijanus.js
+++ b/minijanus.js
@@ -105,7 +105,7 @@ JanusSession.prototype.receive = function(signal) {
   }
   if (signal.transaction != null) {
     var handlers = this.txns[signal.transaction];
-    if (signal.janus === "ack" && signal.hint) {
+    if (signal.janus === "ack") {
       // this is an ack of an asynchronously-processed request, we should wait
       // to resolve the promise until the actual response comes in
     } else if (handlers != null) {

--- a/tests.js
+++ b/tests.js
@@ -8,6 +8,10 @@ test('transactions are detected and matched up', function(t) {
   var bq = session.send({ transaction: "wigs" });
   var cq = session.send({ transaction: "pigs" });
 
+  session.receive({ transaction: "figs", janus: "ack" });
+  session.receive({ transaction: "wigs", janus: "ack" });
+  session.receive({ transaction: "pigs", janus: "ack", hint: "Asynchronously processing some pigs." });
+
   session.receive({ transaction: "pigs", rats: "pats" });
   session.receive({ just: "kidding" });
   session.receive({}, t);
@@ -27,17 +31,21 @@ test('transaction timeouts happen', function(t) {
   var session = new mj.JanusSession(signal => {}, { timeoutMs: 5 });
 
   var aq = session.send({ transaction: "lazy" }).then(
-    resp => t.error(true, "Request should have failed!"),
-    err => t.ok(true, "Timeout should have fired!")
+    resp => { t.fail("Request should have failed!"); return resp; },
+    err => { t.pass("Timeout should have fired!"); return err; }
   );
   var bq = session.send({ transaction: "hasty" }).then(
-    resp => t.ok(true, "Request should have succeeded!"),
-    err => t.error(true, "Timeout shouldn't have fired!")
+    resp => { t.pass("Request should have succeeded!"); return resp; },
+    err => { t.fail("Timeout shouldn't have fired!"); return err; }
   );
 
-  setTimeout(() => session.receive({ transaction: "hasty", "phew": "just-in-time" }, 1));
+  session.receive({ transaction: "lazy", janus: "ack" });
+  session.receive({ transaction: "hasty", janus: "ack" });
 
-  Promise.all([aq, bq]).then(() => {
+  setTimeout(() => session.receive({ transaction: "hasty", phew: "just-in-time" }, 1));
+
+  Promise.all([aq, bq]).then(results => {
+    t.deepEqual(results[1], { transaction: "hasty", phew: "just-in-time" });
     t.deepEqual(session.txns, {});
     t.end();
   });


### PR DESCRIPTION
The plugin can actually opt not to produce a hint, so the previous version would fail to recognize some acks, and treat them as transaction responses. See the Janus core code here: https://github.com/meetecho/janus-gateway/blob/master/janus.c#L1289

Resolves #3.