### PR TITLE
Do not rely upon destroy response before shutting down keepalive

### DIFF
--- a/minijanus.js
+++ b/minijanus.js
@@ -88,9 +88,9 @@ JanusSession.prototype.create = function() {
 
 /** Destroys this session. **/
 JanusSession.prototype.destroy = function() {
-  return this.send("destroy").then(() => {
-    this._killKeepalive();
-  });
+  // Note that this message, unlike others, does *not* receive a response from janus, so there is no promise returned.
+  this.send("destroy");
+  this._killKeepalive();
 };
 
 /**


### PR DESCRIPTION
It turns out Janus does not send a response message in reply to `destroy` messages. The result is that the promise returned from `destroy` is never resolved and also the keepalive routine is never terminated. This updates the API to no longer return a promise and also optimistically ends the keepalive loop.