### PR TITLE
Always dispose of timeouts on session destroy.

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -109,7 +109,7 @@ JanusSession.prototype.dispose = function() {
     if (this.txns.hasOwnProperty(txId)) {
       var txn = this.txns[txId];
       clearTimeout(txn.timeout);
-      txn.reject(new Error("Janus session disposed"));
+      txn.reject(new Error("Janus session was disposed."));
       delete this.txns[txId];
     }
   }
@@ -225,7 +225,9 @@ JanusSession.prototype._killKeepalive = function() {
 JanusSession.prototype._resetKeepalive = function() {
   this._killKeepalive();
   if (this.options.keepaliveMs) {
-    this.keepaliveTimeout = setTimeout(() => this._sendKeepalive(), this.options.keepaliveMs);
+    this.keepaliveTimeout = setTimeout(() => {
+      this._sendKeepalive().catch(e => console.error("Error received from keepalive: ", e));
+    }, this.options.keepaliveMs);
   }
 };
 

--- a/bundle.js
+++ b/bundle.js
@@ -87,11 +87,32 @@ JanusSession.prototype.create = function() {
   });
 };
 
-/** Destroys this session. **/
+/**
+ * Destroys this session. Note that upon destruction, Janus will also close the signalling transport (if applicable) and
+ * any open WebRTC connections.
+ **/
 JanusSession.prototype.destroy = function() {
-  // Note that this message, unlike others, does *not* receive a response from janus, so there is no promise returned.
-  this.send("destroy");
+  return this.send("destroy").then((resp) => {
+    this.dispose();
+    return resp;
+  });
+};
+
+/**
+ * Disposes of this session in a way such that no further incoming signalling messages will be processed.
+ * Outstanding transactions will be rejected.
+ **/
+JanusSession.prototype.dispose = function() {
   this._killKeepalive();
+  this.eventHandlers = {};
+  for (var txId in this.txns) {
+    if (this.txns.hasOwnProperty(txId)) {
+      var txn = this.txns[txId];
+      clearTimeout(txn.timeout);
+      txn.reject(new Error("Janus session disposed"));
+      delete this.txns[txId];
+    }
+  }
 };
 
 /**
@@ -141,7 +162,7 @@ JanusSession.prototype.receive = function(signal) {
     var txn = this.txns[signal.transaction];
     if (txn == null) {
       // this is a response to a transaction that wasn't caused via JanusSession.send, or a plugin replied twice to a
-      // single request, or something else that isn't under our purview; that's fine
+      // single request, or the session was disposed, or something else that isn't under our purview; that's fine
       return;
     }
 
@@ -151,9 +172,7 @@ JanusSession.prototype.receive = function(signal) {
       return;
     }
 
-    if (txn.timeout != null) {
-      clearTimeout(txn.timeout);
-    }
+    clearTimeout(txn.timeout);
 
     delete this.txns[signal.transaction];
     (this.isError(signal) ? txn.reject : txn.resolve)(signal);
@@ -161,31 +180,38 @@ JanusSession.prototype.receive = function(signal) {
 };
 
 /**
- * Sends a signal associated with this session. Signals should be JSON-serializable objects. Returns a promise that will
- * be resolved or rejected when a response to this signal is received, or when no response is received within the
- * session timeout.
+ * Sends a signal associated with this session, beginning a new transaction. Returns a promise that will be resolved or
+ * rejected when a response is received in the same transaction, or when no response is received within the session
+ * timeout.
  **/
 JanusSession.prototype.send = function(type, signal) {
-  var txid = (this.nextTxId++).toString();
-  signal = Object.assign({ janus: type, transaction: txid }, signal);
-  if (this.id != null) { // this.id is undefined in the special case when we're sending the session create message
-    signal = Object.assign({ session_id: this.id }, signal);
-  }
-  if (this.options.verbose) {
-    console.debug("Outgoing Janus signal: ", signal);
-  }
+  signal = Object.assign({ transaction: (this.nextTxId++).toString() }, signal);
   return new Promise((resolve, reject) => {
     var timeout = null;
     if (this.options.timeoutMs) {
       timeout = setTimeout(() => {
         delete this.txns[signal.transaction];
-        reject(new Error("Signalling message with txid " + txid + " timed out."));
+        reject(new Error("Signalling message with txid " + signal.transaction + " timed out."));
       }, this.options.timeoutMs);
     }
     this.txns[signal.transaction] = { resolve: resolve, reject: reject, timeout: timeout, type: type };
-    this.output(JSON.stringify(signal));
-    this._resetKeepalive();
+    this._transmit(type, signal);
   });
+};
+
+JanusSession.prototype._transmit = function(type, signal) {
+  signal = Object.assign({ janus: type }, signal);
+
+  if (this.id != null) { // this.id is undefined in the special case when we're sending the session create message
+    signal = Object.assign({ session_id: this.id }, signal);
+  }
+
+  if (this.options.verbose) {
+    console.debug("Outgoing Janus signal: ", signal);
+  }
+
+  this.output(JSON.stringify(signal));
+  this._resetKeepalive();
 };
 
 JanusSession.prototype._sendKeepalive = function() {
@@ -193,9 +219,7 @@ JanusSession.prototype._sendKeepalive = function() {
 };
 
 JanusSession.prototype._killKeepalive = function() {
-  if (this.keepaliveTimeout) {
-    clearTimeout(this.keepaliveTimeout);
-  }
+  clearTimeout(this.keepaliveTimeout);
 };
 
 JanusSession.prototype._resetKeepalive = function() {

--- a/minijanus.js
+++ b/minijanus.js
@@ -108,7 +108,7 @@ JanusSession.prototype.dispose = function() {
     if (this.txns.hasOwnProperty(txId)) {
       var txn = this.txns[txId];
       clearTimeout(txn.timeout);
-      txn.reject(new Error("Janus session disposed"));
+      txn.reject(new Error("Janus session was disposed."));
       delete this.txns[txId];
     }
   }
@@ -224,7 +224,9 @@ JanusSession.prototype._killKeepalive = function() {
 JanusSession.prototype._resetKeepalive = function() {
   this._killKeepalive();
   if (this.options.keepaliveMs) {
-    this.keepaliveTimeout = setTimeout(() => this._sendKeepalive(), this.options.keepaliveMs);
+    this.keepaliveTimeout = setTimeout(() => {
+      this._sendKeepalive().catch(e => console.error("Error received from keepalive: ", e));
+    }, this.options.keepaliveMs);
   }
 };
 

--- a/minijanus.js
+++ b/minijanus.js
@@ -88,7 +88,8 @@ JanusSession.prototype.create = function() {
 
 /** Destroys this session. **/
 JanusSession.prototype.destroy = function() {
-  // Note that this message, unlike others, does *not* receive a response from janus, so there is no promise returned.
+  // This message will not receive a response from the server.
+  // It will also be rejected at the bottom of this method so we add an empty catch handler.
   this.send("destroy").catch((e) => {});
 
   this._killKeepalive();

--- a/minijanus.js
+++ b/minijanus.js
@@ -89,9 +89,7 @@ JanusSession.prototype.create = function() {
 /** Destroys this session. **/
 JanusSession.prototype.destroy = function() {
   // Note that this message, unlike others, does *not* receive a response from janus, so there is no promise returned.
-  try {
-    this.send("destroy").catch((e) => {});
-  } catch (e) {}
+  this.send("destroy").catch((e) => {});
 
   this._killKeepalive();
 
@@ -99,7 +97,7 @@ JanusSession.prototype.destroy = function() {
     if (this.txns.hasOwnProperty(txnId)) {
       var txn = this.txns[txnId];
       clearTimeout(txn.timeout);
-      txn.reject(`Transaction ${txnId} failed because the JanusSession was destroyed.`);
+      txn.reject("Janus session destroyed");
     }
   }
 };

--- a/minijanus.js
+++ b/minijanus.js
@@ -89,8 +89,19 @@ JanusSession.prototype.create = function() {
 /** Destroys this session. **/
 JanusSession.prototype.destroy = function() {
   // Note that this message, unlike others, does *not* receive a response from janus, so there is no promise returned.
-  this.send("destroy");
+  try {
+    this.send("destroy").catch((e) => {});
+  } catch (e) {}
+
   this._killKeepalive();
+
+  for (var txnId in this.txns) {
+    if (this.txns.hasOwnProperty(txnId)) {
+      var txn = this.txns[txnId];
+      clearTimeout(txn.timeout);
+      txn.reject(`Transaction ${txnId} failed because the JanusSession was destroyed.`);
+    }
+  }
 };
 
 /**

--- a/minijanus.js
+++ b/minijanus.js
@@ -86,7 +86,10 @@ JanusSession.prototype.create = function() {
   });
 };
 
-/** Destroys this session. **/
+/**
+ * Destroys this session. Note that upon destruction, Janus will also close the signalling transport (if applicable) and
+ * any open WebRTC connections.
+ **/
 JanusSession.prototype.destroy = function() {
   return this.send("destroy").then((resp) => {
     this.dispose();
@@ -94,19 +97,21 @@ JanusSession.prototype.destroy = function() {
   });
 };
 
+/**
+ * Disposes of this session in a way such that no further incoming signalling messages will be processed.
+ * Outstanding transactions will be rejected.
+ **/
 JanusSession.prototype.dispose = function() {
   this._killKeepalive();
-
+  this.eventHandlers = {};
   for (var txId in this.txns) {
     if (this.txns.hasOwnProperty(txId)) {
       var txn = this.txns[txId];
       clearTimeout(txn.timeout);
-      txn.reject("Janus session disposed");
+      txn.reject(new Error("Janus session disposed"));
       delete this.txns[txId];
     }
   }
-
-  this.eventHandlers = {};
 };
 
 /**
@@ -156,7 +161,7 @@ JanusSession.prototype.receive = function(signal) {
     var txn = this.txns[signal.transaction];
     if (txn == null) {
       // this is a response to a transaction that wasn't caused via JanusSession.send, or a plugin replied twice to a
-      // single request, or something else that isn't under our purview; that's fine
+      // single request, or the session was disposed, or something else that isn't under our purview; that's fine
       return;
     }
 
@@ -174,31 +179,26 @@ JanusSession.prototype.receive = function(signal) {
 };
 
 /**
- * Sends a signal associated with this session. Signals should be JSON-serializable objects. Returns a promise that will
- * be resolved or rejected when a response to this signal is received, or when no response is received within the
- * session timeout.
+ * Sends a signal associated with this session, beginning a new transaction. Returns a promise that will be resolved or
+ * rejected when a response is received in the same transaction, or when no response is received within the session
+ * timeout.
  **/
 JanusSession.prototype.send = function(type, signal) {
-  var txid = (this.nextTxId++).toString();
-  signal = Object.assign({ transaction: txid }, signal);
-
+  signal = Object.assign({ transaction: (this.nextTxId++).toString() }, signal);
   return new Promise((resolve, reject) => {
     var timeout = null;
     if (this.options.timeoutMs) {
       timeout = setTimeout(() => {
         delete this.txns[signal.transaction];
-        reject(new Error("Signalling message with txid " + txid + " timed out."));
+        reject(new Error("Signalling message with txid " + signal.transaction + " timed out."));
       }, this.options.timeoutMs);
     }
     this.txns[signal.transaction] = { resolve: resolve, reject: reject, timeout: timeout, type: type };
-    this.transmit(type, signal);
+    this._transmit(type, signal);
   });
 };
 
-/**
- * Sends a signal associated with this session without waiting for a response. Signals should be JSON-serializable objects.
- */
-JanusSession.prototype.transmit = function(type, signal) {
+JanusSession.prototype._transmit = function(type, signal) {
   signal = Object.assign({ janus: type }, signal);
 
   if (this.id != null) { // this.id is undefined in the special case when we're sending the session create message

--- a/tests.js
+++ b/tests.js
@@ -84,3 +84,30 @@ test('transaction timeouts happen', function(t) {
     t.end();
   });;
 });
+
+
+test('session is properly disposed of on destroy', function(t) {
+  var session = new mj.JanusSession(signal => {}, { timeoutMs: 5, keepaliveMs: null });
+
+  var message1 = session.send("message", { transaction: "message1" }).then(
+    resp => { t.pass("Message 1 was received."); return resp; },
+    err => { t.fail("Message should have been received."); return err; }
+  );
+  var message2 = session.send("message", { transaction: "message2" }).then(
+    resp => {  t.fail("Message 2 shouldn't have been received."); return resp; },
+    err => { t.pass("Message 2 was correctly rejected."); return err; }
+  );
+
+  session.receive({ transaction: "message1", value: "test" });
+
+  session.destroy();
+
+  Promise.all([message1, message2]).then(results => {
+    t.deepEqual(results[0], { transaction: "message1", value: "test" });
+    t.deepEqual(session.txns, {});
+    t.end();
+  }).catch(err => {
+    t.fail(err);
+    t.end();
+  });
+});

--- a/tests.js
+++ b/tests.js
@@ -86,7 +86,7 @@ test('transaction timeouts happen', function(t) {
 });
 
 
-test('session is properly disposed of on destroy', function(t) {
+test('session transactions are properly disposed of', function(t) {
   var session = new mj.JanusSession(signal => {}, { timeoutMs: 5, keepaliveMs: null });
 
   var message1 = session.send("message", { transaction: "message1" }).then(
@@ -100,7 +100,7 @@ test('session is properly disposed of on destroy', function(t) {
 
   session.receive({ transaction: "message1", value: "test" });
 
-  session.destroy();
+  session.dispose();
 
   Promise.all([message1, message2]).then(results => {
     t.deepEqual(results[0], { transaction: "message1", value: "test" });


### PR DESCRIPTION
In `naf-janus-adapter` when the WebSocket was closed or in a closing state, `send("destroy)` would error preventing the clean up of the keep alive timeout. We also need to clear any remaining transaction timeout handlers and reject their promises.